### PR TITLE
Return a Promise

### DIFF
--- a/ios/SafariWebAuth.m
+++ b/ios/SafariWebAuth.m
@@ -23,7 +23,9 @@ RCT_EXPORT_MODULE()
     return dispatch_get_main_queue();
 }
 
-RCT_EXPORT_METHOD(requestAuth:(NSURL *)requestURL)
+RCT_EXPORT_METHOD(requestAuth:(NSURL *)requestURL
+                     resolver:(RCTPromiseResolveBlock)resolve
+                     rejecter:(RCTPromiseRejectBlock)reject)
 {
     if (!requestURL) {
         RCTLogError(@"[SafariWebAuth] You must specify a url.");
@@ -39,7 +41,12 @@ RCT_EXPORT_METHOD(requestAuth:(NSURL *)requestURL)
             _authenticationVC = nil;
 
             if (callbackURL) {
+                NSLog(@"[SafariWebAuth] Auth success, callbackURL = %@", callbackURL);
+                resolve([callbackURL absoluteString]);
                 [RCTSharedApplication() openURL:callbackURL];
+            } else {
+                NSLog(@"[SafariWebAuth] Auth failure, error = %@", error);
+                reject(@"requestAuth", @"Auth failed", error);
             }
         }];
 


### PR DESCRIPTION
It would be usefuil if `requestAuth` returned a `Promise`.

I can see that this module hasn't been updated for a long time, but AFAICT it still works fine, so I hope you are still accepting PRs :-)