### PR TITLE
FEATURE: Use promises instead of custom URL schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-safari-web-auth
 
-Login authentication bridge for iOS 13+ using [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession).
+Login authentication for iOS 13+ using [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession).
 
 ## Getting started
 
@@ -10,13 +10,32 @@ Login authentication bridge for iOS 13+ using [ASWebAuthenticationSession](https
 
 ## Usage
 
+Since version 2.0.0, the library uses promises (previously, it used custom URL schemes in the app) to handle callbacks.
+
+Example:
+
 ```javascript
 import SafariWebAuth from "react-native-safari-web-auth";
 import { Platform } from "react-native";
 
-if (Platform.OS === "ios") {
-  SafariWebAuth.requestAuth("https://your.site.com/auth", "customurlscheme");
+async function handleAuthentication() {
+  if (Platform.OS === "ios") {
+    try {
+      const authRequest = await SafariWebAuth.requestAuth(
+        "AUTH_URL",
+        "urlScheme", // use a custom scheme that will be returned to the RN app via the callback.
+        true
+        // the third parameter sets the prefersEphemeralWebBrowserSession variable in ASWebAuthenticationSession,
+        // when true, it skips iOS dialog prompt but uses incognito mode (i.e. user always has to log in)
+      );
+
+      if (authRequest) {
+        console.log(authRequest);
+        // decode (if necessary) and then use the URL in your app
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
 }
 ```
-
-Should be used in conjunction with a custom URL scheme for your app that handles the login callback.

--- a/ios/SafariWebAuth.mm
+++ b/ios/SafariWebAuth.mm
@@ -2,7 +2,12 @@
 
 @interface RCT_EXTERN_MODULE(SafariWebAuth, NSObject)
 
-RCT_EXTERN_METHOD(requestAuth:(NSString *)url callbackURLScheme:(NSString *)callbackURLScheme)
+RCT_EXTERN_METHOD(requestAuth:
+  (NSString *)url
+  callbackURLScheme:(NSString *)callbackURLScheme
+  ephemeral:(BOOL *)ephemeral
+  resolver:(RCTPromiseResolveBlock)resolve
+  rejecter:(RCTPromiseRejectBlock)reject)
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-safari-web-auth",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "Authentication helper for react-native projects using ASWebAuthentication. iOS 13+ only.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a breaking change, the `requestAuth` interface now requires 3 parameters: 
- url
- scheme (used by iOS to return the correct URL)
- boolean flag for ephemeral session (true or false)

See README for updated usage example. 